### PR TITLE
Adjust QoS Settings for LiDAR

### DIFF
--- a/spark_fast_lio/src/spark_fast_lio.cpp
+++ b/spark_fast_lio/src/spark_fast_lio.cpp
@@ -85,21 +85,23 @@ SPARKFastLIO2::SPARKFastLIO2(const rclcpp::NodeOptions &options)
   auto g_vec = declare_parameter<std::vector<double>>("gravity_alignment.g_base", {0.0, 0.0, -1.0});
   g_base_ << g_vec[0], g_vec[1], g_vec[2];
 
-  auto sensor_qos = rclcpp::SensorDataQoS();
+  rclcpp::QoS lidar_qos(rclcpp::KeepLast(10));
+  lidar_qos.reliable();
+  lidar_qos.durability_volatile();
   sub_lidar_      = create_subscription<sensor_msgs::msg::PointCloud2>(
       "lidar",
-      sensor_qos,
+      lidar_qos,
       std::bind(&SPARKFastLIO2::standardLiDARCallback, this, std::placeholders::_1));
 
 #if defined(LIVOX_ROS_DRIVER_FOUND) && LIVOX_ROS_DRIVER_FOUND
   sub_lidar_livox_ = create_subscription<livox_ros_driver2::msg::CustomMsg>(
       "lidar",
-      sensor_qos,
+      lidar_qos,
       std::bind(&SPARKFastLIO2::livoxLidarCallback, this, std::placeholders::_1));
 #endif
-
+  auto imu_qos = rclcpp::SensorDataQoS();
   sub_imu_ = create_subscription<sensor_msgs::msg::Imu>(
-      "imu", sensor_qos, std::bind(&SPARKFastLIO2::imuCallback, this, std::placeholders::_1));
+      "imu", imu_qos, std::bind(&SPARKFastLIO2::imuCallback, this, std::placeholders::_1));
 
   rclcpp::QoS qos((rclcpp::SystemDefaultsQoS().keep_last(1).durability_volatile()));
   pub_cloud_full_  = create_publisher<sensor_msgs::msg::PointCloud2>("cloud_registered", qos);


### PR DESCRIPTION
This PR adjusts the QoS profiles.

- **LiDAR**: switched from `SensorDataQoS()` (BestEffort) to `Reliable + Volatile`
  to prevent frame drops when playing large PointCloud2 topics from rosbag2.
- **IMU**: kept `BestEffort + Volatile` for low-latency high-rate (100–400 Hz) data.

### Reason
BestEffort for LiDAR causes noticeable frame losses when bag files use RELIABLE publishers
or large PointCloud2 messages. Reliable mode resolves this without increasing latency.

### Verification
Tested with:
- [HK_MEMS_Dataset](https://github.com/RuanJY/HK_MEMS_Dataset)
- ROS 2 Humble
- Ouster 32 LiDAR @ 10Hz + IMU @ 400Hz
- rosbag2_player (RELIABLE)
LiDAR frame rate stable (10Hz), IMU smooth.

**LiDAR message duration(s) before adjustment:**
<img width="554" height="523" alt="before_adjustment" src="https://github.com/user-attachments/assets/1e77281a-f887-4c16-bbf6-6d93199e8b24" />

**LiDAR message duration(s) after adjustment:**
<img width="554" height="527" alt="after_adjustment" src="https://github.com/user-attachments/assets/d8fe4557-d184-42bc-8d87-4ccc1c7c0bc5" />



