### PR TITLE
Fix ros2 runtime error

### DIFF
--- a/spark_fast_lio/src/spark_fast_lio.cpp
+++ b/spark_fast_lio/src/spark_fast_lio.cpp
@@ -960,7 +960,7 @@ bool SPARKFastLIO2::syncPackages(MeasureGroup &meas, bool verbose) {
 
   if (last_imu_timestamp_.seconds() < lidar_end_time_) {
     if (verbose) {
-      static rclcpp::Time last_imu_timestamp_prev;
+      static rclcpp::Time last_imu_timestamp_prev(now());
       // To only print out when changes occur
       if (last_imu_timestamp_prev != last_imu_timestamp_) {
         RCLCPP_INFO(this->get_logger(),


### PR DESCRIPTION
* origin version: raises runtime error when starting ros2 bag play
* modify: initialize last_imu_timestamp_prev using now()
```
[spark_lio_mapping-1] terminate called after throwing an instance of 'std::runtime_error' 
[spark_lio_mapping-1] what(): can't compare times with different time sources [ERROR] 
[spark_lio_mapping-1]: process has died [pid 87296, exit code -6, cmd 
```